### PR TITLE
easier printing of variable types

### DIFF
--- a/content/posts/2017-08-07-print-variable-types.md
+++ b/content/posts/2017-08-07-print-variable-types.md
@@ -20,20 +20,19 @@ package main
 
 import (
     "fmt"
-    "reflect"
 )
 
 func main() {
     // Will print 'int'
     anInt := 1234
-    fmt.Println(reflect.TypeOf(anInt).String())
+    fmt.Printf("%T\n", anInt)
 
     // Will print 'string'
     aString := "Hello World"
-    fmt.Println(reflect.TypeOf(aString).String())
+    fmt.Printf("%T\n", aString)
 
     // Will print 'float64'
     aFloat := 3.14
-    fmt.Println(reflect.TypeOf(aFloat).String())
+    fmt.Printf("%T\n", aFloat)
 }
 ```


### PR DESCRIPTION
There is no need for the reflect package in this case.
the `fmt` package can do this already, as [documented here](https://golang.org/pkg/fmt/#hdr-Printing)