### PR TITLE
StatusCode is not converted to string with strconv

### DIFF
--- a/content/posts/2017-08-06-get-response-status-code.md
+++ b/content/posts/2017-08-06-get-response-status-code.md
@@ -45,7 +45,4 @@ func main() {
 }
 ```
 
-StatusCode will be an integer, so in our example we convert it with `strconv` to a string before printing it to screen.
-
-
 ![Get the status code of a http request](/img/2017/response-http-status.png)


### PR DESCRIPTION
StatusCode is not converted to string with strconv since [this commit](https://github.com/eddturtle/golangcode-site/commit/8dd00cc97514861d551bb3db678fb2782d730fca).

So no need to mention it in [the blogpost](https://golangcode.com/get-the-http-response-status-code/). ✅ 