### PR TITLE
Update 2017-04-09-get-a-url-parameter-from-a-request.md

### DIFF
--- a/content/posts/2017-04-09-get-a-url-parameter-from-a-request.md
+++ b/content/posts/2017-04-09-get-a-url-parameter-from-a-request.md
@@ -41,7 +41,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
     keys, ok := r.URL.Query()["key"]
     
-    if !ok || len(keys) < 1 {
+    if !ok || len(keys[0]) < 1 {
         log.Println("Url Param 'key' is missing")
         return
     }


### PR DESCRIPTION
If we're calling 'localhost:8080/?key=' (nothing after equal sign), len(keys) == 1
But still, there is no value provided
Instead of checking keys' length (which is needless), we can just check if first element is an empty string. If so, parameter is missing, despite we have key provided